### PR TITLE
Include local participant on android

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -714,6 +714,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
                 for (RemoteParticipant participant : participants) {
                     participantsArray.pushMap(buildParticipant(participant));
                 }
+                participantsArray.pushMap(buildParticipant(localParticipant));
                 event.putArray("participants", participantsArray);
 
                 pushEvent(CustomTwilioVideoView.this, ON_CONNECTED, event);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/blackuy/react-native-twilio-video-webrtc.git"
   },
   "homepage": "https://github.com/blackuy/react-native-twilio-video-webrtc",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Twilio Video WebRTC for React Native.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This way it'll be consistent with the ios implementation.

ios source
https://github.com/actio-tech/react-native-twilio-video-webrtc/blob/master/ios/RCTTWVideoModule.m#L440-L445