### PR TITLE
Update android video constraints

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -220,9 +220,9 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
     private VideoConstraints buildVideoConstraints() {
         return new VideoConstraints.Builder()
                 .minVideoDimensions(VideoDimensions.CIF_VIDEO_DIMENSIONS)
-                .maxVideoDimensions(VideoDimensions.CIF_VIDEO_DIMENSIONS)
+                .maxVideoDimensions(VideoDimensions.HD_720P_VIDEO_DIMENSIONS)
                 .minFps(5)
-                .maxFps(15)
+                .maxFps(24)
                 .build();
     }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/blackuy/react-native-twilio-video-webrtc.git"
   },
   "homepage": "https://github.com/blackuy/react-native-twilio-video-webrtc",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Twilio Video WebRTC for React Native.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
"Max" constraints are updated: 24fps + HD video (720p)

Inspired by https://github.com/blackuy/react-native-twilio-video-webrtc/pull/153

Related docs: https://www.twilio.com/docs/video/android-v1-specifying-video-constraints