### PR TITLE
Implement setRemoteAudioEnabled method

### DIFF
--- a/android/src/main/java/com/actiotech/twiliovideorn/TwilioVideoModule.java
+++ b/android/src/main/java/com/actiotech/twiliovideorn/TwilioVideoModule.java
@@ -575,18 +575,19 @@ public class TwilioVideoModule extends ReactContextBaseJavaModule implements Lif
     }
 
     @ReactMethod
-    public void setRemoteAudioEnabled(boolean enabled) {
+    public void setRemoteAudioEnabled(String participantSid, boolean enabled) {
         if (room != null) {
             for (RemoteParticipant rp : room.getRemoteParticipants()) {
-                for (AudioTrackPublication at : rp.getAudioTracks()) {
-                    if (at.getAudioTrack() != null) {
-                        ((RemoteAudioTrack) at.getAudioTrack()).enablePlayback(enabled);
+                if (rp.getSid().equals(participantSid)) {
+                    for (AudioTrackPublication at : rp.getAudioTracks()) {
+                        if (at.getAudioTrack() != null) {
+                            ((RemoteAudioTrack) at.getAudioTrack()).enablePlayback(enabled);
+                        }
                     }
                 }
             }
         }
     }
-
 
     private void convertBaseTrackStats(BaseTrackStats bs, WritableMap result) {
         result.putString("codec", bs.codec);

--- a/index.d.ts
+++ b/index.d.ts
@@ -145,6 +145,8 @@ declare module 'react-native-twilio-video-webrtc' {
 
     setLocalAudioEnabled: (enabled: boolean) => Promise<boolean>;
 
+    setRemoteAudioEnabled: (participantSid: string, enabled: boolean) => void;
+
     onRoomDidConnect: RoomEventCb;
 
     onRoomDidDisconnect: RoomErrorEventCb;
@@ -218,6 +220,7 @@ declare module 'react-native-twilio-video-webrtc' {
   class TwilioVideoView extends React.Component<TwilioVideoViewProps> {
     setLocalVideoEnabled: (enabled: boolean) => Promise<boolean>;
     setLocalAudioEnabled: (enabled: boolean) => Promise<boolean>;
+    setRemoteAudioEnabled: (participantSid: string, enabled: boolean) => void;
     setBluetoothHeadsetConnected: (enabled: boolean) => Promise<boolean>;
     connect: (options: iOSConnectParams | androidConnectParams) => void;
     disconnect: () => void;

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -145,7 +145,7 @@ RCT_EXPORT_MODULE();
     }
 }
 
-RCT_EXPORT_METHOD(setRemoteAudioPlayback:(NSString *)participantSid enabled:(BOOL)enabled) {
+RCT_EXPORT_METHOD(setRemoteAudioEnabled:(NSString *)participantSid enabled:(BOOL)enabled) {
     TVIRemoteParticipant *participant = [self.room getRemoteParticipantWithSid:participantSid];
     if (participant) {
         NSArray<TVIRemoteAudioTrackPublication *> *trackPublications = participant.remoteAudioTracks;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/blackuy/react-native-twilio-video-webrtc.git"
   },
   "homepage": "https://github.com/blackuy/react-native-twilio-video-webrtc",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Twilio Video WebRTC for React Native.",
   "main": "index.js",
   "scripts": {

--- a/src/TwilioVideo.js
+++ b/src/TwilioVideo.js
@@ -141,6 +141,15 @@ class TwilioVideo {
   };
 
   /**
+   * Enable/disable remove audio for specific participant
+   * @param participantSid
+   * @param enabled
+   */
+  setRemoteAudioEnabled = (participantSid, enabled) => {
+    this.nativeModule.setRemoteAudioEnabled(participantSid, enabled);
+  };
+
+  /**
    * Flip between the front and back camera
    */
   flipCamera = () => {

--- a/src/TwilioVideoView.js
+++ b/src/TwilioVideoView.js
@@ -126,6 +126,15 @@ export default class extends React.PureComponent {
   };
 
   /**
+   * Enable/disable remove audio for specific participant
+   * @param participantSid
+   * @param enabled
+   */
+  setRemoteAudioEnabled = (participantSid, enabled) => {
+    TwilioVideo.setRemoteAudioEnabled(participantSid, enabled);
+  };
+
+  /**
    * Flip between the front and back camera
    */
   flipCamera = () => {


### PR DESCRIPTION
Implemented `setRemoteAudioEnabled: (participantSid: string, enabled: boolean) => void` method to enable/disable remote audio for specific participant. It was already implemented, I just made it consistent across platforms. Also the original `setRemoteAudioEnabled(boolean enabled)` method on Android does not make sense because when a new participant joins his/her audio will not be disabled.

I decided not to implement array of participants because every time a new participant joins his/her audio needs to be manually disabled anyway. I will implement a separate method which accepts array of `sid`s if there will be performance problems with muting participants one by one.