### PR TITLE
Bump Twilio Video iOS version to 3.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/blackuy/react-native-twilio-video-webrtc.git"
   },
   "homepage": "https://github.com/blackuy/react-native-twilio-video-webrtc",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "description": "Twilio Video WebRTC for React Native.",
   "main": "index.js",
   "scripts": {

--- a/react-native-twilio-video-webrtc.podspec
+++ b/react-native-twilio-video-webrtc.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'TwilioVideo', '~> 3.6.1'
+  s.dependency 'TwilioVideo', '~> 3.7.2'
 end


### PR DESCRIPTION
It fixes some crashes and memory leaks (https://github.com/twilio/twilio-video-ios/issues/114)

https://www.twilio.com/docs/video/changelog-twilio-video-ios-version-3x#372-november-3-2020